### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To use Nalu add the following dependencies to your pom:
     <version>LATEST</version>
 </dependency>
 <dependency>
-    <groupId>com.githubnalukit</groupId>
+    <groupId>com.github.nalukit</groupId>
     <artifactId>nalu-processor</artifactId>
     <version>LATEST</version>
     <scope>provided</scope>


### PR DESCRIPTION
The groupId of the second maven dependency in the 'Using' section misses a dot.