### PR TITLE
docs(integration): update Maven groupId for Nalu dependencies

### DIFF
--- a/wiki/02.-Integration.md
+++ b/wiki/02.-Integration.md
@@ -39,12 +39,12 @@ See [#9](https://github.com/NaluKit/nalu/issues/9) for current status before dow
 Working with Maven, you need to add the following maven dependency:
 ```XML
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu</artifactId>
       <version>LATEST</version>
     </dependency>
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-processor</artifactId>
       <version>LATEST</version>
       <scope>provided</scope>
@@ -56,7 +56,7 @@ Depending on the widget library your project is using, you have to add another d
 In case the project is using a widget library based on elemental2 or elemento or the project is using a library like [Domino-UI](https://github.com/DominoKit/domino-ui), add the following dependency to your pom:
 ```XML
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-plugin-elemental2</artifactId>
       <version>LATEST</version>
     </dependency>
@@ -66,12 +66,12 @@ In case the project is using a widget library based on elemental2 or elemento or
 In case the project is based on GWT widgets, add the following plugin to your pom:
 ```XML
    <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-plugin-gwt</artifactId>
       <version>LATEST</version>
     </dependency>
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-plugin-gwt-processor</artifactId>
       <version>LATEST</version>
       <scope>provided</scope>
@@ -87,12 +87,12 @@ At the moment Nalu requires at least Java 17 and GWT 2.12.2. We recommend to use
 You need to add the following maven dependency:
 ```XML
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu</artifactId>
       <version>LATEST</version>
     </dependency>
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-processor</artifactId>
       <version>LATEST</version>
       <scope>provided</scope>
@@ -104,7 +104,7 @@ Depending on the widget library your project is using, you have to add another d
 In case the project is using a widget library based on elemental2 or elemento or the project is using a library like [Domino-UI](https://github.com/DominoKit/domino-ui), add the following dependency to your pom:
 ```XML
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-plugin-elemental2</artifactId>
       <version>LATEST</version>
     </dependency>
@@ -114,12 +114,12 @@ In case the project is using a widget library based on elemental2 or elemento or
 In case the project is based on GWT widgets, add the following plugin to your pom:
 ```XML
    <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-plugin-gwt</artifactId>
       <version>LATEST</version>
     </dependency>
     <dependency>
-      <groupId>io.github.nalukit.nalu</groupId>
+      <groupId>io.github.nalukit</groupId>
       <artifactId>nalu-plugin-gwt-processor</artifactId>
       <version>LATEST</version>
       <scope>provided</scope>


### PR DESCRIPTION
This PR updates the Maven dependency examples in the Integration documentation to reflect the current artifact coordinates.